### PR TITLE
add permissions bypass so we dont try to change a bunch of things

### DIFF
--- a/rootfs/etc/cont-init.d/58-permissions
+++ b/rootfs/etc/cont-init.d/58-permissions
@@ -13,15 +13,17 @@
 # See /LICENSE for more information.
 
 . /etc/init-base
-chown -R p3terx:p3terx ${DOWNLOAD_DIR}
-chown -R p3terx:p3terx ${ARIA2_CONF_DIR}
-if [[ -z ${PUID} && -z ${PGID} ]] || [[ ${PUID} = 65534 && ${PGID} = 65534 ]]; then
-    echo -e "${WARN} Ignore permission settings."
-    chmod -v 777 ${DOWNLOAD_DIR}
-    chmod -vR 777 ${ARIA2_CONF_DIR}
-else
-    chmod -v u=rwx ${DOWNLOAD_DIR}
-    chmod -v 600 ${ARIA2_CONF_DIR}/*
-    chmod -v 755 ${SCRIPT_DIR}
-    chmod -v 700 ${SCRIPT_DIR}/*
+if [[-z ${BYPASS_PERMISSIONS} ]]; then
+    chown -R p3terx:p3terx ${DOWNLOAD_DIR}
+    chown -R p3terx:p3terx ${ARIA2_CONF_DIR}
+    if [[ -z ${PUID} && -z ${PGID} ]] || [[ ${PUID} = 65534 && ${PGID} = 65534 ]]; then
+        echo -e "${WARN} Ignore permission settings."
+        chmod -v 777 ${DOWNLOAD_DIR}
+        chmod -vR 777 ${ARIA2_CONF_DIR}
+    else
+        chmod -v u=rwx ${DOWNLOAD_DIR}
+        chmod -v 600 ${ARIA2_CONF_DIR}/*
+        chmod -v 755 ${SCRIPT_DIR}
+        chmod -v 700 ${SCRIPT_DIR}/*
+    fi
 fi


### PR DESCRIPTION
Not sure if this is useful to you, but I added an option in case someone doesn't want your container mucking with their permissions. 

Especially with the recursive flags. this chown can be destructive depending on the target.

I did it as a test for an empty environment variable to avoid changing the default behavior.